### PR TITLE
Update to 1.16.1 (kinda)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.4.12'
+	id 'fabric-loom' version '0.4-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -19,7 +19,7 @@ dependencies {
 	mappings "net.fabricmc:yarn:${project.minecraft_version}+build.${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-	modImplementation "net.fabricmc.fabric-api:fabric-api:+"
+	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,14 @@
 org.gradle.jvmargs  = -Xmx1G
 
 #Fabric properties
-minecraft_version   = 1.16-rc1
-yarn_mappings       = 4
-loader_version      = 0.8.8+build.202
+minecraft_version   = 1.16.1
+yarn_mappings       = 20
+loader_version      = 0.8.9+build.203
 
 #Mod properties
 mod_version         = 1.0.2
 maven_group         = de.siphalor.amecsapi
 archives_base_name  = amecsapi
+
+#Dependencies
+fabric_api_version  = 0.14.1+build.372-1.16

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/de/siphalor/amecs/api/AmecsKeyBinding.java
+++ b/src/main/java/de/siphalor/amecs/api/AmecsKeyBinding.java
@@ -3,7 +3,6 @@ package de.siphalor.amecs.api;
 import de.siphalor.amecs.impl.duck.IKeyBinding;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.fabricmc.fabric.api.client.keybinding.FabricKeyBinding;
 import net.minecraft.client.options.KeyBinding;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.util.Identifier;


### PR DESCRIPTION
Apparently there's no actual errors, just outdated stuff (and a single unused reference to Fabric's deprecated keybind API).